### PR TITLE
incorrect requirement listed

### DIFF
--- a/content/lore/quests.md
+++ b/content/lore/quests.md
@@ -477,7 +477,7 @@ The rod becomes clickable after an action but...
 
 {{< tip >}}
 
-**Requirements** : [Energy Pyramid]({{< ref "lore/special_tools#energy-pyramid" >}})
+**Requirements** : Part of [Rod Under The Arch]({{< ref "lore/special_tools#rod-under-the-arch" >}})
 
 {{< /tip >}}
 


### PR DESCRIPTION
Rod in police station had incorrect requirement of energy pyramid - fixed to part of rod under arch