### PR TITLE
Broken/Missing Links

### DIFF
--- a/content/casebook/_index.md
+++ b/content/casebook/_index.md
@@ -22,6 +22,18 @@ Notes and observations found during investigations.
 - [Movie Codes](movie_codes/)
 {{< /tab>}}
 
+{{< tab "Museum" >}}
+- [Museum](museum/)
+	- [Brave](museum/knight/)
+	- [Greed](museum/greed/)
+{{< /tab>}}
+
+{{< tab "Monoliths" >}}
+- [Monoliths](monoliths/)
+	- [Details](monoliths/details/)
+	- [Locations](monoliths/locations/)
+{{< /tab>}}
+
 {{< tab "Quantum Room" >}}
 - [Quantum Room](quantum/)
 	- [Window Messages](quantum/window_messages/)
@@ -29,14 +41,10 @@ Notes and observations found during investigations.
 	- [Mysterious Steam](quantum/steam/)
 {{< /tab>}}
 
-{{< tab "Museum" >}}
-- [Museum](museum/)
-	- [The Knight](museum/knight/)
-{{< /tab>}}
-
 {{< tab "Notes & Messages" >}}
 - [Notes & Messages](notes/)
 	- [Agency](notes/agency/)
+	- [Marcus](notes/marcus)
 	- [Mr. B](notes/mrb)
 	- [Mr. Brookhaven](notes/mrbrookhaven/)
 	- [Madison](notes/madison/)

--- a/content/casebook/notes/marcus.md
+++ b/content/casebook/notes/marcus.md
@@ -12,11 +12,10 @@ Marcus, Mr.Brookhaven's son has left only one note signed by him. Does this mean
 
 ## Shipping / Criminal RP House
 
-
-{{< youtube "TCznqHlgmn0" >}}
-
 {{< tip >}}
 **Requirements** : None
+
+Part of [Criminal Lair](/lore/quests/#criminal-lair)
 {{< /tip >}}
 
 **Steps:**

--- a/content/lore/quests.md
+++ b/content/lore/quests.md
@@ -645,8 +645,8 @@ All of these steps will be in the Shipping / Criminal RP house.
 
 These steps are broken into 2 parts
 
-- [Criminal Lair](#criminal-lair)
-- [Agency Lair](#agency-lair)
+- [Criminal Lair](/lore/quests/#criminal-lair)
+- [Agency Lair](/lore/quests/#agency-lair)
 {{< /tip >}}
 
 {{< tip >}}

--- a/content/lore/quests.md
+++ b/content/lore/quests.md
@@ -500,7 +500,8 @@ The rod becomes clickable after an action but...
 Unlocks the Blue Keypad in the Agency Bunker
 
 `Recommended starting the video at 1m:17sec`
-{{< youtube "gysIfNUKpbw" >}}
+
+{{< liteyoutube videoid="gysIfNUKpbw" params="start=77" >}}
 
 {{< tip >}}
 **Requirements** : None

--- a/content/lore/tools.md
+++ b/content/lore/tools.md
@@ -23,7 +23,7 @@ It's also recommended to have the following in your inventory at some point:
 Connecting the laptop to.... _who_ we aren't exactly sure. Pretty positive it's connecting to the **agency**.
 We do this because sometimes the laptop will give us messages, hints/tips along the way.
 
-{{< youtube "6b_tvg4R4YA" >}}
+{{< liteyoutube videoid="6b_tvg4R4YA" >}}
 
 
 {{< tip >}}


### PR DESCRIPTION
- YT link to criminal /shipping note removed by uploaded
- Broken link to criminal and agency lair under quests
- added menu links for marcus notes in casebook