### PR TITLE
bump hugo build version and deps

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -1,4 +1,5 @@
 # Sample workflow for building and deploying a Hugo site to GitHub Pages
+# Check https://gohugo.io/hosting-and-deployment/hosting-on-github/ for updates
 name: Deploy Hugo site to Pages
 
 on:
@@ -32,22 +33,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.118.2
+      HUGO_VERSION: 0.123.0
     steps:
       - name: Install Hugo CLI
         run: |
           wget -O ${{ runner.temp }}/hugo.deb https://github.com/gohugoio/hugo/releases/download/v${HUGO_VERSION}/hugo_extended_${HUGO_VERSION}_linux-amd64.deb \
           && sudo dpkg -i ${{ runner.temp }}/hugo.deb          
-      - name: Install Dart Sass Embedded
-        run: sudo snap install dart-sass-embedded
+      - name: Install Dart Sass
+        run: sudo snap install dart-sass
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -61,7 +62,7 @@ jobs:
             --minify \
             --baseURL "https://solve.bhmystery.com/"          
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v2
         with:
           path: ./public
 
@@ -75,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v3


### PR DESCRIPTION
- HUGO_VERSION: 0.123.0 bump from 0.118.2
- dart-sass-embedded deprecated now installing dart-sass
- actions/checkout@v4 bumped from v3
- actions/configure-pages@v4 bumped from v3
- actions/upload-pages-artifact@v2 bumped from v1
- actions/deploy-pages@v3 bumped from v2